### PR TITLE
Don't redefine PAGE_SIZE if it's already defined

### DIFF
--- a/ffmalloc.c
+++ b/ffmalloc.c
@@ -99,8 +99,10 @@ typedef unsigned char byte;
 #define POOL_SIZE_BITS 22
 #define POOL_SIZE (ONE64 << POOL_SIZE_BITS)
 
+#ifndef PAGE_SIZE
 // The size of a single page of memory from the OS
 #define PAGE_SIZE UINT64_C(4096)
+#endif
 
 // Half of an OS memory page
 #define HALF_PAGE UINT64_C(2048)


### PR DESCRIPTION
This should fix the following warnings:

```
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE -DUSE_FF_PREFIX ffmalloc.c -o ffmallocmt.o
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE -DUSE_FF_PREFIX -DFFSINGLE_THREADED ffmalloc.c -o ffmallocst.o
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE -DUSE_FF_PREFIX -DFFSINGLE_THREADED -DFF_INSTRUMENTED ffmalloc.c -o ffmallocinst.o
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE ffmalloc.c -o ffmallocnpmt.o
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE -DFFSINGLE_THREADED ffmalloc.c -o ffmallocnpst.o
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
gcc -Wall -Wextra -Wno-unknown-pragmas -fPIC -c -g -O3 -DFF_GROWLARGEREALLOC -D_GNU_SOURCE -DFFSINGLE_THREADED -DFF_INSTRUMENTED ffmalloc.c -o ffmallocnpinst.o
ffmalloc.c:98: warning: "PAGE_SIZE" redefined
   98 | #define PAGE_SIZE UINT64_C(4096)
      | 
In file included from /usr/include/fortify/stdlib.h:29,
                 from ffmalloc.c:46:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE
      | 
gcc -o libffmallocmt.so -shared -fPIC -pthread ffmallocmt.o
gcc -o libffmallocst.so -shared -fPIC ffmallocst.o
gcc -o libffmallocinst.so -shared -fPIC ffmallocinst.o
gcc -o libffmallocnpmt.so -shared -fPIC -pthread ffmallocnpmt.o
gcc -o libffmallocnpst.so -shared -fPIC ffmallocnpst.o
gcc -o libffmallocnpinst.so -shared -fPIC ffmallocnpinst.o
```